### PR TITLE
get filters is called before m_filters is initialized when import def…

### DIFF
--- a/Import Definition Files/ImportDefinitionProfile.cs
+++ b/Import Definition Files/ImportDefinitionProfile.cs
@@ -36,6 +36,10 @@ namespace AssetTools
 
 		public List<Filter> GetFilters( bool userFiltersOnly = false )
 		{
+			//get filters is called before m_filters is initialized when import definition is created
+			if (m_Filters == null)
+				return null;
+		
 			List<Filter> filters = new List<Filter>(m_Filters);
 			if( m_FilterToFolder )
 				filters.Add( new Filter( Filter.ConditionTarget.Directory, Filter.Condition.StartsWith, DirectoryPath ) );


### PR DESCRIPTION
get filters is called before m_filters is initialized when import definition is created

return null when get filters is called prematurely.